### PR TITLE
Enable client server tracing in same process

### DIFF
--- a/Src/zipkin4net.middleware.owin/Src/ZipkinMiddleware.cs
+++ b/Src/zipkin4net.middleware.owin/Src/ZipkinMiddleware.cs
@@ -29,6 +29,7 @@ namespace zipkin4net.Middleware
         {
             var traceContext = traceExtractor.Extract(context.Request.Headers);
             var trace = traceContext == null ? Trace.Create() : Trace.CreateFromId(traceContext);
+            trace.CurrentSpan.IsServerSide = true;
 
             Trace.Current = trace;
 

--- a/Src/zipkin4net.middleware.owin/Tests/Helpers/OwinHelper.cs
+++ b/Src/zipkin4net.middleware.owin/Tests/Helpers/OwinHelper.cs
@@ -9,29 +9,43 @@ namespace zipkin4net.Middleware.Tests.Helpers
 {
     static class OwinHelper
     {
-        internal static async Task<string> Call(Action<IAppBuilder> startup, Func<HttpClient, Task<string>> clientCall)
+        internal static async Task<string> Call(Action<IAppBuilder> startup, Func<HttpClient, Task<string>> clientCall, Action<HttpMessageHandler> rememberTestHttpMessageHandler = null)
         {
             using (var server = TestServer.Create(startup))
             {
+                rememberTestHttpMessageHandler?.Invoke(server.Handler);
                 using (var client = new HttpClient(server.Handler))
                 {
                     return await clientCall(client);
                 }
             }
         }
-        internal static Action<IAppBuilder> DefaultStartup(string serviceName, Func<IOwinContext, string> getRpc = null, Func<PathString, bool> routeFilter = null)
+        internal static Action<IAppBuilder> DefaultStartup(string serviceName, Func<IOwinContext, string> getRpc = null, Func<PathString, bool> routeFilter = null, Func<IOwinContext, Task> runHandler = null)
         {
             return
                 app =>
                 {
                     app.UseZipkinTracer(serviceName, getRpc, routeFilter);
 
-                    app.Run(async context =>
+                    if (runHandler == null)
                     {
-                        context.Response.ContentType = "text/plain";
-                        await context.Response.WriteAsync(DateTime.Now.ToString());
-                    });
+                        runHandler = async context =>
+                        {
+                            context.Response.ContentType = "text/plain";
+                            await context.Response.WriteAsync(DateTime.Now.ToString());
+                        };
+                    }
+                    app.Run(runHandler);
                 };
+        }
+
+        internal static Func<HttpClient, Task<string>> ClientCall(Uri urlToCall)
+        {
+            return async client =>
+            {
+                var response = await client.GetAsync(urlToCall);
+                return await response.Content.ReadAsStringAsync();
+            };
         }
     }
 }

--- a/Src/zipkin4net.middleware.owin/Tests/WhenOwinMiddlewareIsActiveWithRealDispatcher.cs
+++ b/Src/zipkin4net.middleware.owin/Tests/WhenOwinMiddlewareIsActiveWithRealDispatcher.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Moq;
+using NSubstitute;
+using NUnit.Framework;
+using zipkin4net.Internal.Recorder;
+using zipkin4net.Middleware.Tests.Helpers;
+using zipkin4net.Tracers.Zipkin;
+using zipkin4net.Transport.Http;
+
+namespace zipkin4net.Middleware.Tests
+{
+    using static OwinHelper;
+
+    public class WhenOwinMiddlewareIsActiveWithRealDispatcher
+    {
+        private const string SERVICE_NAME = "OwinTest";
+
+        private Mock<IReporter> _reporter;
+        private List<Span> _reportedSpans;
+        private HttpMessageHandler _testHttpMessageHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            var logger = Substitute.For<ILogger>();
+
+            _reporter = new Mock<IReporter>();
+            _reportedSpans = new List<Span>();
+            _reporter.Setup(x => x.Report(Capture.In(this._reportedSpans)));
+
+            var tracer = new ZipkinTracer(_reporter.Object, new Statistics());
+
+            _testHttpMessageHandler = null;
+
+            TraceManager.SamplingRate = 1.0f;
+            TraceManager.RegisterTracer(tracer);
+            TraceManager.Start(logger);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TraceManager.ClearTracers();
+            TraceManager.Stop();
+        }
+
+        [Test]
+        public async Task Check_That_dispatcher_is_called_with_expected_records_on_GET_call()
+        {
+            //Arrange
+            var urlToCall = new Uri("http://testserver/api/outer");
+
+            //Act
+            var responseContent = await Call(DefaultStartup(SERVICE_NAME, runHandler: RunHandler), ClientCall(urlToCall), x => _testHttpMessageHandler = x);
+            Assert.IsNotEmpty(responseContent);
+
+            Assert.AreEqual(3, _reportedSpans.Count);
+            AssertSpanReported(new[] {"sr", "ss"}, "/api/outer");
+            AssertSpanReported(new[] {"cs", "cr"});
+            AssertSpanReported(new[] {"sr", "ss"}, "/api/inner");
+        }
+
+        private async Task RunHandler(IOwinContext context)
+        {
+            if (context.Request.Path.HasValue
+                && context.Request.Path.Value.EndsWith("api/outer"))
+            {
+                // for the sake of simplicity, this is mocking that the "outer" endpoint will call some "inner" endpoint
+                var uriBuilder = new UriBuilder(context.Request.Uri);
+                uriBuilder.Path = uriBuilder.Path.Replace("outer", "inner");
+
+                using (var httpClient = new HttpClient(new TracingHandler(SERVICE_NAME, _testHttpMessageHandler)))
+                {
+                    var response = await httpClient.GetAsync(uriBuilder.Uri);
+                    var content = await response.Content.ReadAsStringAsync();
+
+                    await context.Response.WriteAsync(content);
+                }
+            }
+
+            // else: e.g. path == "api/inner"
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(DateTime.Now.ToString());
+        }
+
+        private void AssertSpanReported(string[] annotations, string path = null)
+        {
+            var query = _reportedSpans.Where(span => span.Annotations != null && span.Annotations.Select(x => x.Value).SequenceEqual(annotations));
+            if (path != null)
+            {
+                query = query.Where(span => span.BinaryAnnotations != null && span.BinaryAnnotations.Any(x => HasKeyValue(x, "http.path", path)));
+            }
+            var count = query.Count();
+            Assert.AreEqual(1, count,
+                $"Found {count} reported spans with annotations [{string.Join(",", annotations)}]{(path != null ? " and http.path '{path}'" : "")}");
+        }
+
+        private static bool HasKeyValue(BinaryAnnotation binaryAnnotation, string key, string value)
+        {
+            var valueAsString = Encoding.UTF8.GetString(binaryAnnotation.Value);
+            return binaryAnnotation.Key == key
+                   && valueAsString == value;
+        }
+    }
+}

--- a/Src/zipkin4net/Src/ITraceContext.cs
+++ b/Src/zipkin4net/Src/ITraceContext.cs
@@ -23,6 +23,10 @@ namespace zipkin4net
         /// </summary>
         long SpanId { get; }
         /// <summary>
+        /// Indicates if it is the server-side context of the trace, or the client-side context otherwise.
+        /// </summary>
+        bool IsServerSide { get; set; }
+        /// <summary>
         /// Returns a list of additional data propagated through this trace.
         ///
         /// <p>The contents are intentionally opaque, deferring to <see cref="Propagation.IPropagation{K}"/> to define. An

--- a/Src/zipkin4net/Src/SpanState.cs
+++ b/Src/zipkin4net/Src/SpanState.cs
@@ -15,6 +15,8 @@ namespace zipkin4net
 
         public long SpanId { get; private set; }
 
+        public bool IsServerSide { get; set; }
+
         internal const long NoTraceIdHigh = 0;
 
         [Obsolete("Please use Sampled method instead")]
@@ -108,7 +110,8 @@ namespace zipkin4net
             return TraceIdHigh == other.TraceIdHigh
                    && TraceId == other.TraceId
                    && ParentSpanId == other.ParentSpanId
-                   && SpanId == other.SpanId;
+                   && SpanId == other.SpanId
+                   && IsServerSide == other.IsServerSide;
         }
 
         public override bool Equals(object obj)
@@ -127,15 +130,17 @@ namespace zipkin4net
                 hashCode = (hashCode * 397) ^ TraceId.GetHashCode();
                 hashCode = (hashCode * 397) ^ ParentSpanId.GetHashCode();
                 hashCode = (hashCode * 397) ^ SpanId.GetHashCode();
+                hashCode = (hashCode * 397) ^ IsServerSide.GetHashCode();
                 return hashCode;
             }
         }
 
         public override string ToString()
         {
-            return string.Format("{0}{1}.{2}<:{3}",
+            return string.Format("{0}{1}.{2}<:{3}{4}",
                 TraceIdHigh == SpanState.NoTraceIdHigh ? "" : TraceIdHigh.ToString(), TraceId, SpanId,
-                ParentSpanId.HasValue ? ParentSpanId.Value.ToString(CultureInfo.InvariantCulture) : "_");
+                ParentSpanId.HasValue ? ParentSpanId.Value.ToString(CultureInfo.InvariantCulture) : "_",
+                IsServerSide ? "(s)" : "(c)");
         }
 
         public bool? Sampled { get; private set; }


### PR DESCRIPTION
See https://github.com/openzipkin/zipkin4net/issues/233

The intention of this is rather to show up the problem and how it _might_ be solved. It's not meant to be _THE_ solution for the problem, but it can help to understand it.

I have tried to add a Unit test for reproduction as a copy of WhenOwinMiddlewareIsActive, but this time with a real dispatcher and a mocked IReporter, so we can see and check what will be reported.

The test will fail without further modifications to the zipkin4net code, because the second assertion (cs, cr) will fail. As a solution attempt, the ITraceContext contains the information if it's a server side or a client side context. That information is included in Equals/GetHashCode so that the context won't be equal on server and client side, even if it would be equal considering the other properties.

Again, it's mainly a way to show the problem and no way to provide the best possible solution. For that my knowledge of the library and Zipkin per-se is too superficial. Also I left out the aspnetcore middleware (didn't even test if the problem occurs there too; but if, the solution might be similar).